### PR TITLE
Update frontmatter license to be nullable

### DIFF
--- a/src/blocks/types/frontMatter.ts
+++ b/src/blocks/types/frontMatter.ts
@@ -4,7 +4,7 @@ import { Author } from './author';
 // When the values are null indicates it has been explicitly set to null.
 export interface BlockFrontMatterProps {
   authors?: Author[] | null;
-  licenses?: { content: string | null; code: string | null };
+  licenses?: { content: string | null; code: string | null } | null;
   doi?: string | null;
   open_access?: boolean | null;
   github?: string | null;


### PR DESCRIPTION
License field should be nullable. When Individual license fields are null indicates missing license. If the whole licenses field s null, we can treat it as to be overriden by project. 