### PR TITLE
👩‍💻 Add SiteConfig DTO

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -10,6 +10,7 @@ export interface ProjectLinks extends BaseLinks {
   blocks: string;
   team: string;
   manifest?: string;
+  site: string;
 }
 
 export type ReferenceLabelMap = Record<CustomizableReferenceKind, string>;

--- a/src/sites.spec.ts
+++ b/src/sites.spec.ts
@@ -1,4 +1,22 @@
-import { createCurvespaceUrl, getCurvespaceParts, isCurvespaceDomain } from './sites';
+import { ValidationOptions } from './utils/validators';
+import {
+  createCurvespaceUrl,
+  getCurvespaceParts,
+  isCurvespaceDomain,
+  validateSiteAction,
+  validateSiteAnalytics,
+  validateSiteConfig,
+  validateSiteDesign,
+  validateSiteNavItem,
+  validateVenue,
+  validateSiteProject,
+} from './sites';
+
+let opts: ValidationOptions;
+
+beforeEach(() => {
+  opts = { property: 'test', messages: {} };
+});
 
 describe('Curvespace Links', () => {
   test.each([
@@ -37,5 +55,211 @@ describe('Curvespace Links', () => {
     expect(() => createCurvespaceUrl('some-', 'one')).toThrow();
     expect(() => createCurvespaceUrl('some', 'one&')).toThrow();
     expect(() => createCurvespaceUrl('some', 'one-')).toThrow();
+  });
+});
+
+describe('validateVenue', () => {
+  it('empty object returns self', async () => {
+    expect(validateVenue({}, opts)).toEqual({});
+  });
+  it('object with title/url returns self', async () => {
+    const venue = {
+      title: 'test',
+      url: 'http://example.com',
+    };
+    expect(validateVenue(venue, opts)).toEqual(venue);
+  });
+  it('invalid keys ignored', async () => {
+    expect(validateVenue({ title: 'test', extra: '' }, opts)).toEqual({ title: 'test' });
+  });
+  it('string is invalid', async () => {
+    expect(validateVenue('test', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+});
+
+describe('validateSiteProject', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteProject({}, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('valid site project returns self', async () => {
+    const siteProj = {
+      path: 'my-dir',
+      slug: 'proj',
+    };
+    expect(validateSiteProject(siteProj, opts)).toEqual(siteProj);
+  });
+  it('invalid slug errors', async () => {
+    expect(validateSiteProject({ path: 'my-dir', slug: '#' }, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+});
+
+describe('validateSiteNavItem', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteNavItem({}, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('valid site nav folder returns self', async () => {
+    const siteNavFolder = {
+      title: 'my-folder',
+      children: [],
+    };
+    expect(validateSiteNavItem(siteNavFolder, opts)).toEqual(siteNavFolder);
+  });
+  it('valid site nav page returns self', async () => {
+    const siteNavPage = {
+      title: 'my-folder',
+      url: '/my-folder',
+    };
+    expect(validateSiteNavItem(siteNavPage, opts)).toEqual(siteNavPage);
+  });
+  it('invalid children errors', async () => {
+    expect(validateSiteNavItem({ title: 'my-folder', children: 'a' }, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('invalid child errors', async () => {
+    expect(validateSiteNavItem({ title: 'my-folder', children: ['a'] }, opts)).toEqual({
+      title: 'my-folder',
+      children: [],
+    });
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('invalid url errors', async () => {
+    expect(validateSiteNavItem({ title: 'my-folder', url: '/a/a/a' }, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('invalid full url errors', async () => {
+    expect(
+      validateSiteNavItem({ title: 'my-folder', url: 'https://example.com/a/a' }, opts),
+    ).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+});
+
+describe('validateSiteAction', () => {
+  it('empty object errors', async () => {
+    expect(validateSiteAction({}, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('valid site project returns self', async () => {
+    const siteAction = {
+      title: 'example',
+      url: 'https://example.com',
+      static: false,
+    };
+    expect(validateSiteAction(siteAction, opts)).toEqual(siteAction);
+  });
+  it('invalid url errors', async () => {
+    expect(validateSiteAction({ title: 'example', url: '/a' }, opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+});
+
+describe('validateSiteDesign', () => {
+  it('empty object returns self', async () => {
+    expect(validateSiteDesign({}, opts)).toEqual({});
+  });
+  it('valid site design returns self', async () => {
+    const siteDesign = {
+      hide_authors: true,
+    };
+    expect(validateSiteDesign(siteDesign, opts)).toEqual(siteDesign);
+  });
+});
+
+describe('validateSiteAnalytics', () => {
+  it('empty object returns self', async () => {
+    expect(validateSiteAnalytics({}, opts)).toEqual({});
+  });
+  it('valid site design returns self', async () => {
+    const siteAnalytics = {
+      google: 'google',
+      plausible: 'plausible',
+    };
+    expect(validateSiteAnalytics(siteAnalytics, opts)).toEqual(siteAnalytics);
+  });
+});
+
+describe('validateSiteConfig', () => {
+  it('valid site config returns self', async () => {
+    const siteConfig = {
+      projects: [{ path: 'my-proj', slug: 'test' }],
+      nav: [{ title: 'cool folder', children: [{ title: 'cool page', url: '/test/cool-page' }] }],
+      actions: [{ title: 'Go To Example', url: 'https://example.com', static: false }],
+      domains: ['test.curve.space'],
+      twitter: 'test',
+      logo: 'curvenote.png',
+      logo_text: 'test logo',
+      favicon: 'curvenote.png',
+      analytics: {
+        google: 'google',
+        plausible: 'plausible',
+      },
+      design: {
+        hide_authors: true,
+      },
+    };
+    expect(validateSiteConfig(siteConfig, opts)).toEqual(siteConfig);
+  });
+  it('invalid list values are filtered', async () => {
+    expect(
+      validateSiteConfig(
+        {
+          projects: [{ path: 'my-proj', slug: '/my/proj' }],
+          nav: [{ title: 'cool folder', children: 'a' }],
+          actions: [{ title: 'Go To Example', url: '/my/proj', static: false }],
+          domains: ['example.com'],
+        },
+        opts,
+      ),
+    ).toEqual({
+      projects: [],
+      nav: [],
+      actions: [],
+      domains: [],
+    });
+    expect(opts.messages.errors?.length).toEqual(4);
+  });
+  it('invalid required values error', async () => {
+    expect(
+      validateSiteConfig(
+        {
+          projects: 'a',
+          nav: [
+            { title: 'cool folder', children: [{ title: 'cool page', url: '/test/cool-page' }] },
+          ],
+          actions: [{ title: 'Go To Example', url: 'https://example.com', static: false }],
+          domains: 'test.curve.space',
+        },
+        opts,
+      ),
+    ).toEqual({
+      nav: [{ title: 'cool folder', children: [{ title: 'cool page', url: '/test/cool-page' }] }],
+      actions: [{ title: 'Go To Example', url: 'https://example.com', static: false }],
+    });
+    expect(opts.messages.errors?.length).toEqual(2);
+  });
+  it('empty config returns self', async () => {
+    expect(validateSiteConfig({}, opts)).toEqual({});
+  });
+  it('domains are coerced, deduplicated', async () => {
+    expect(
+      validateSiteConfig(
+        {
+          domains: [
+            'my.example.com',
+            'http://another.example.com',
+            'https://example.curve.space',
+            'example.curve.space',
+          ],
+        },
+        opts,
+      ),
+    ).toEqual({
+      domains: ['my.example.com', 'another.example.com', 'example.curve.space'],
+    });
+    expect(opts.messages.errors).toEqual(undefined);
   });
 });

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -56,8 +56,8 @@ export interface Venue {
 }
 
 export interface SiteProject {
-  remote: string;
   slug: string;
+  remote?: string;
   path?: string;
 }
 
@@ -94,9 +94,8 @@ export interface PartialSiteConfig {
   domains?: string[] | null;
   twitter?: string | null;
   logo?: string | null;
-  logoText?: string | null;
+  logo_text?: string | null;
   favicon?: string | null;
-  buildPath?: string | null;
   analytics?: SiteAnalytics | null;
   design?: SiteDesign | null;
 }

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -182,15 +182,25 @@ export function validateVenue(input: any, opts: ValidationOptions) {
 }
 
 export function validateSiteProject(input: any, opts: ValidationOptions) {
-  const value = validateObjectKeys(input, { required: ['path', 'slug'] }, opts);
+  const value = validateObjectKeys(
+    input,
+    { required: ['slug'], optional: ['remote', 'path'] },
+    opts,
+  );
   if (value === undefined) return undefined;
-  const path = validateString(value.path, incrementOptions('path', opts));
   const slug = validateString(value.slug, {
     ...incrementOptions('slug', opts),
     regex: '^[a-zA-Z0-9._-]+$',
   });
-  if (!path || !slug) return undefined;
-  return { path, slug } as SiteProject;
+  if (!slug) return undefined;
+  const output: SiteProject = { slug };
+  if (defined(value.path)) {
+    output.path = validateString(value.path, incrementOptions('path', opts));
+  }
+  if (defined(value.remote)) {
+    output.remote = validateString(value.remote, incrementOptions('remote', opts));
+  }
+  return output;
 }
 
 export function validateSiteNavItem(
@@ -329,13 +339,10 @@ export function validateSiteConfigKeys(
     output.logo = validateString(value.logo, incrementOptions('logo', opts));
   }
   if (defined(value.logoText)) {
-    output.logoText = validateString(value.logoText, incrementOptions('logoText', opts));
+    output.logo_text = validateString(value.logoText, incrementOptions('logoText', opts));
   }
   if (defined(value.favicon)) {
     output.favicon = validateString(value.favicon, incrementOptions('favicon', opts));
-  }
-  if (defined(value.buildPath)) {
-    output.buildPath = validateString(value.buildPath, incrementOptions('buildPath', opts));
   }
   if (defined(value.analytics)) {
     output.analytics = validateSiteAnalytics(value.analytics, incrementOptions('analytics', opts));

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1,5 +1,6 @@
 import { getDate } from './helpers';
-import { JsonObject } from './types';
+import { ProjectId } from './projects';
+import { BaseLinks, JsonObject } from './types';
 
 export interface UploadFileInfo {
   path: string;
@@ -35,6 +36,70 @@ export interface DnsRouter {
   created_by: string;
   date_created: Date;
   date_modified: Date;
+}
+
+export interface Venue {
+  title?: string;
+  url?: string;
+}
+
+export interface SiteProject {
+  remote: string;
+  slug: string;
+  path?: string;
+}
+
+export interface SiteNavPage {
+  title: string;
+  url: string;
+}
+
+export interface SiteNavFolder {
+  title: string;
+  children: (SiteNavPage | SiteNavFolder)[];
+}
+
+export interface SiteAction extends SiteNavPage {
+  static?: boolean;
+}
+
+export interface SiteAnalytics {
+  google?: string;
+  plausible?: string;
+}
+
+export interface SiteDesign {
+  hide_authors?: boolean;
+}
+
+export interface PartialSiteConfig {
+  title?: string;
+  description?: string;
+  venue?: Venue;
+  projects?: SiteProject[];
+  nav?: (SiteNavPage | SiteNavFolder)[];
+  actions?: SiteAction[];
+  domains?: string[];
+  twitter?: string;
+  logo?: string;
+  logoText?: string;
+  favicon?: string;
+  buildPath?: string;
+  analytics?: SiteAnalytics;
+  design?: SiteDesign;
+}
+
+export interface SiteConfigLinks extends BaseLinks {
+  project: string;
+  publish: string;
+}
+
+export interface SiteConfig extends PartialSiteConfig {
+  id: ProjectId;
+  created_by: string;
+  date_created: Date;
+  date_modified: Date;
+  links: SiteConfigLinks;
 }
 
 const CURVE_SPACE = /^(?:(?:https?:)?\/\/)?([a-z0-9_]{3,20})(?:-([a-z0-9_]{1,30}))?\.curve\.space$/;

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1,3 +1,15 @@
+import {
+  defined,
+  incrementOptions,
+  ValidationOptions,
+  validateKeys,
+  validateObject,
+  validateObjectKeys,
+  validateString,
+  validateUrl,
+  validateList,
+  validateBoolean,
+} from './utils/validators';
 import { getDate } from './helpers';
 import { ProjectId } from './projects';
 import { BaseLinks, JsonObject } from './types';
@@ -151,4 +163,184 @@ export function dnsRouterFromDTO(id: string, json: JsonObject): DnsRouter {
     date_created: getDate(json.date_created),
     date_modified: getDate(json.date_modified),
   };
+}
+
+/**
+ * Validate Venue object against the schema
+ *
+ * If 'value' is a string, venue will be coerced to object { title: value }
+ */
+export function validateVenue(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: ['title', 'url'] }, opts);
+  if (value === undefined) return undefined;
+  const output: Venue = {};
+  if (defined(value.title)) {
+    output.title = validateString(value.title, incrementOptions('title', opts));
+  }
+  if (defined(value.url)) {
+    output.url = validateUrl(value.url, incrementOptions('url', opts));
+  }
+  return output;
+}
+
+export function validateSiteProject(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { required: ['path', 'slug'] }, opts);
+  if (value === undefined) return undefined;
+  const path = validateString(value.path, incrementOptions('path', opts));
+  const slug = validateString(value.slug, {
+    ...incrementOptions('slug', opts),
+    regex: '^[a-zA-Z0-9._-]+$',
+  });
+  if (!path || !slug) return undefined;
+  return { path, slug } as SiteProject;
+}
+
+export function validateSiteNavItem(
+  input: any,
+  opts: ValidationOptions,
+): SiteNavPage | SiteNavFolder | undefined {
+  let value = validateObject(input, opts);
+  if (value === undefined) return undefined;
+  if (defined(value.children)) {
+    // validate as SiteNavFolder
+    value = validateKeys(value, { required: ['title', 'children'] }, opts);
+    if (value === undefined) return undefined;
+    const title = validateString(value.title, incrementOptions('title', opts));
+    const children = validateList(
+      value.children,
+      incrementOptions('children', opts),
+      (child, index) => {
+        return validateSiteNavItem(child, incrementOptions(`children.${index}`, opts));
+      },
+    );
+    if (title === undefined || !children) return undefined;
+    return { title, children } as SiteNavFolder;
+  }
+  // validate as SiteNavItem
+  value = validateKeys(value, { required: ['title', 'url'] }, opts);
+  if (value === undefined) return undefined;
+  const title = validateString(value.title, incrementOptions('title', opts));
+  const url = validateString(value.url, {
+    ...incrementOptions('url', opts),
+    regex: '^(/[a-zA-Z0-9._-]+){1,2}$',
+  });
+  if (title === undefined || !url) return undefined;
+  return { title, url } as SiteNavPage;
+}
+
+export function validateSiteAction(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(
+    input,
+    { required: ['title', 'url'], optional: ['static'] },
+    opts,
+  );
+  if (value === undefined) return undefined;
+  const title = validateString(value.title, incrementOptions('title', opts));
+  if (defined(value.static)) {
+    value.static = validateBoolean(value.static, incrementOptions('static', opts));
+  }
+  const actionUrlValidator = value.static ? validateString : validateUrl;
+  const url = actionUrlValidator(value.url, incrementOptions('url', opts));
+  if (title === undefined || !url) return undefined;
+  return value as SiteAction;
+}
+
+export function validateSiteDesign(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: ['hide_authors'] }, opts);
+  if (value === undefined) return undefined;
+  if (defined(value.hide_authors)) {
+    value.hide_authors = validateBoolean(
+      value.hide_authors,
+      incrementOptions('hide_authors', opts),
+    );
+  }
+  return value as SiteDesign;
+}
+
+export function validateSiteAnalytics(input: any, opts: ValidationOptions) {
+  const value = validateObjectKeys(input, { optional: ['google', 'plausible'] }, opts);
+  if (value === undefined) return undefined;
+  if (defined(value.google)) {
+    value.google = validateString(value.google, incrementOptions('google', opts));
+  }
+  if (defined(value.plausible)) {
+    value.plausible = validateString(value.plausible, incrementOptions('plausible', opts));
+  }
+  return value as SiteAnalytics;
+}
+
+export function validateSiteConfigKeys(value: Record<string, any>, opts: ValidationOptions) {
+  const output: Record<string, any> = {};
+  if (defined(value.title)) {
+    output.title = validateString(value.title, incrementOptions('title', opts));
+  }
+  if (defined(value.description)) {
+    output.description = validateString(value.description, incrementOptions('description', opts));
+  }
+  if (defined(value.venue)) {
+    output.venue = validateVenue(value.venue, incrementOptions('venue', opts));
+  }
+  if (defined(value.projects)) {
+    output.projects = validateList(
+      value.projects,
+      incrementOptions('projects', opts),
+      (proj, index) => {
+        return validateSiteProject(proj, incrementOptions(`projects.${index}`, opts));
+      },
+    );
+  } else {
+    output.projects = [];
+  }
+  if (defined(value.nav)) {
+    output.nav = validateList(value.nav, incrementOptions('nav', opts), (item, index) => {
+      return validateSiteNavItem(item, incrementOptions(`nav.${index}`, opts));
+    });
+  } else {
+    output.nav = [];
+  }
+  if (defined(value.actions)) {
+    output.actions = validateList(
+      value.actions,
+      incrementOptions('actions', opts),
+      (action, index) => {
+        return validateSiteAction(action, incrementOptions(`actions.${index}`, opts));
+      },
+    );
+  } else {
+    output.actions = [];
+  }
+  if (defined(value.domains)) {
+    const domainsOpts = incrementOptions('domains', opts);
+    output.domains = validateList(value.domains, domainsOpts, (domain) => {
+      // Very basic subdomain validation
+      return validateString(domain, { ...domainsOpts, regex: /^.+\..+\..+$/ });
+    });
+  } else {
+    output.domains = [];
+  }
+  if (defined(value.twitter)) {
+    output.twitter = validateString(value.twitter, {
+      ...incrementOptions('twitter', opts),
+      regex: /^@?(\w){1,15}$/,
+    });
+  }
+  if (defined(value.logo)) {
+    output.logo = validateString(value.logo, incrementOptions('logo', opts));
+  }
+  if (defined(value.logoText)) {
+    output.logoText = validateString(value.logoText, incrementOptions('logoText', opts));
+  }
+  if (defined(value.favicon)) {
+    output.favicon = validateString(value.favicon, incrementOptions('favicon', opts));
+  }
+  if (defined(value.buildPath)) {
+    output.buildPath = validateString(value.buildPath, incrementOptions('buildPath', opts));
+  }
+  if (defined(value.analytics)) {
+    output.analytics = validateSiteAnalytics(value.analytics, incrementOptions('analytics', opts));
+  }
+  if (defined(value.design)) {
+    output.design = validateSiteDesign(value.design, incrementOptions('design', opts));
+  }
+  return output as PartialSiteConfig;
 }

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -108,7 +108,6 @@ export interface SiteConfigLinks extends BaseLinks {
 
 export interface SiteConfig extends PartialSiteConfig {
   id: ProjectId;
-  created_by: string;
   date_created: Date;
   date_modified: Date;
   links: SiteConfigLinks;

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -85,20 +85,20 @@ export interface SiteDesign {
 }
 
 export interface PartialSiteConfig {
-  title?: string;
-  description?: string;
-  venue?: Venue;
-  projects?: SiteProject[];
-  nav?: (SiteNavPage | SiteNavFolder)[];
-  actions?: SiteAction[];
-  domains?: string[];
-  twitter?: string;
-  logo?: string;
-  logoText?: string;
-  favicon?: string;
-  buildPath?: string;
-  analytics?: SiteAnalytics;
-  design?: SiteDesign;
+  title?: string | null;
+  description?: string | null;
+  venue?: Venue | null;
+  projects?: SiteProject[] | null;
+  nav?: (SiteNavPage | SiteNavFolder)[] | null;
+  actions?: SiteAction[] | null;
+  domains?: string[] | null;
+  twitter?: string | null;
+  logo?: string | null;
+  logoText?: string | null;
+  favicon?: string | null;
+  buildPath?: string | null;
+  analytics?: SiteAnalytics | null;
+  design?: SiteDesign | null;
 }
 
 export interface SiteConfigLinks extends BaseLinks {
@@ -268,8 +268,11 @@ export function validateSiteAnalytics(input: any, opts: ValidationOptions) {
   return value as SiteAnalytics;
 }
 
-export function validateSiteConfigKeys(value: Record<string, any>, opts: ValidationOptions) {
-  const output: Record<string, any> = {};
+export function validateSiteConfigKeys(
+  value: Record<string, any>,
+  opts: ValidationOptions,
+): PartialSiteConfig {
+  const output: PartialSiteConfig = {};
   if (defined(value.title)) {
     output.title = validateString(value.title, incrementOptions('title', opts));
   }
@@ -341,5 +344,5 @@ export function validateSiteConfigKeys(value: Record<string, any>, opts: Validat
   if (defined(value.design)) {
     output.design = validateSiteDesign(value.design, incrementOptions('design', opts));
   }
-  return output as PartialSiteConfig;
+  return output;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type BaseUrls = {
   profile: string;
   drafts: string;
   blocks: string;
+  sites: string;
   my: string;
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './id';
 export * from './git';
+export * from './validators';

--- a/src/utils/validators.spec.ts
+++ b/src/utils/validators.spec.ts
@@ -50,10 +50,19 @@ describe('incrementOptions', () => {
   it('errors/warnings are not lost', async () => {
     const newOpts = incrementOptions('new', opts);
     if (newOpts.messages) {
-      newOpts.messages.errors = ['a'];
-      newOpts.messages.warnings = ['b', 'c'];
+      newOpts.messages.errors = [{ property: 'a', message: 'x' }];
+      newOpts.messages.warnings = [
+        { property: 'b', message: 'y' },
+        { property: 'c', message: 'z' },
+      ];
     }
-    expect(opts.messages).toEqual({ errors: ['a'], warnings: ['b', 'c'] });
+    expect(opts.messages).toEqual({
+      errors: [{ property: 'a', message: 'x' }],
+      warnings: [
+        { property: 'b', message: 'y' },
+        { property: 'c', message: 'z' },
+      ],
+    });
   });
 });
 
@@ -72,11 +81,11 @@ describe('validateBoolean', () => {
   });
   it('invalid type errors', async () => {
     expect(validateBoolean(0, opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
   it('invalid string errors', async () => {
     expect(validateBoolean('t', opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 
@@ -86,18 +95,18 @@ describe('validateString', () => {
   });
   it('invalid type errors', async () => {
     expect(validateString({}, opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
   it('exceeding maxLenth errors', async () => {
     expect(validateString('abc', { maxLength: 1, ...opts })).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
   it('regex match returns self', async () => {
     expect(validateString('abc', { regex: '^[a-c]{3}$', ...opts })).toEqual('abc');
   });
   it('incompatible regex errors', async () => {
     expect(validateString('abc', { regex: '^[a-c]{2}$', ...opts })).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
   it('escape function runs', async () => {
     expect(validateString('abc', { maxLength: 3, escapeFn: (s) => `${s}${s}`, ...opts })).toEqual(
@@ -112,7 +121,7 @@ describe('validateUrl', () => {
   });
   it('invalid string errors', async () => {
     expect(validateUrl('not a url', opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
   it('valid value includes', async () => {
     expect(validateUrl('https://example.com', { ...opts, includes: 'le.c' })).toEqual(
@@ -123,7 +132,7 @@ describe('validateUrl', () => {
     expect(validateUrl('https://example.com', { ...opts, includes: 'example.org' })).toEqual(
       undefined,
     );
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 
@@ -133,7 +142,7 @@ describe('validateEmail', () => {
   });
   it('invalid email errors', async () => {
     expect(validateEmail('https://example.com', opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 
@@ -157,7 +166,7 @@ describe('validateDate', () => {
   });
   it('invalid date errors', async () => {
     expect(validateDate('https://example.com', opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 
@@ -167,7 +176,7 @@ describe('validateObject', () => {
   });
   it('invalid type errors', async () => {
     expect(validateObject('a', opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 
@@ -186,11 +195,11 @@ describe('validateKeys', () => {
       a: 1,
       b: 2,
     });
-    expect(opts.messages?.warnings.length).toEqual(1);
+    expect(opts.messages.warnings?.length).toEqual(1);
   });
   it('missing required keys errors', async () => {
     expect(validateKeys({ a: 1 }, { required: ['a', 'b'] }, opts)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 
@@ -213,11 +222,11 @@ describe('validateList', () => {
   });
   it('invalid object errors', async () => {
     expect(validateList({}, opts, (val) => val)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
   it('invalid string errors', async () => {
     expect(validateList('abc', opts, (val) => val)).toEqual(undefined);
-    expect(opts.messages?.errors.length).toEqual(1);
+    expect(opts.messages.errors?.length).toEqual(1);
   });
 });
 

--- a/src/utils/validators.spec.ts
+++ b/src/utils/validators.spec.ts
@@ -1,5 +1,6 @@
 import {
   fillMissingKeys,
+  filterKeys,
   incrementOptions,
   ValidationOptions,
   locationSuffix,
@@ -10,6 +11,7 @@ import {
   validateList,
   validateObject,
   validateString,
+  validateSubdomain,
   validateUrl,
 } from './validators';
 
@@ -136,6 +138,39 @@ describe('validateUrl', () => {
   });
 });
 
+describe('validateSubdomain', () => {
+  it('valid value returns self', async () => {
+    expect(validateSubdomain('www.example.com', opts)).toEqual('www.example.com');
+  });
+  it('valid value removes protocol', async () => {
+    expect(validateSubdomain('https://www.example.com', opts)).toEqual('www.example.com');
+  });
+  it('invalid url errors', async () => {
+    expect(validateSubdomain('not a url', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('invalid protocol errors', async () => {
+    expect(validateSubdomain('ftp://www.example.com', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('top-level domain errors', async () => {
+    expect(validateSubdomain('example.com', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('value with path errors', async () => {
+    expect(validateSubdomain('www.example.com/path', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('value with query errors', async () => {
+    expect(validateSubdomain('www.example.com?query=true', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+  it('value with fragment errors', async () => {
+    expect(validateSubdomain('www.example.com#fragment', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+});
+
 describe('validateEmail', () => {
   it('valid email returns self', async () => {
     expect(validateEmail('example@example.com', opts)).toEqual('example@example.com');
@@ -243,5 +278,14 @@ describe('fillMissingKeys', () => {
       b: 2,
       d: 4,
     });
+  });
+});
+
+describe('filterKeys', () => {
+  it('remove existing key', async () => {
+    expect(filterKeys({ a: 1, b: 2 }, ['a'])).toEqual({ a: 1 });
+  });
+  it('remove null', async () => {
+    expect(filterKeys({ a: null }, ['a', 'b'])).toEqual({});
   });
 });

--- a/src/utils/validators.spec.ts
+++ b/src/utils/validators.spec.ts
@@ -1,0 +1,238 @@
+import {
+  fillMissingKeys,
+  incrementOptions,
+  ValidationOptions,
+  locationSuffix,
+  validateBoolean,
+  validateDate,
+  validateEmail,
+  validateKeys,
+  validateList,
+  validateObject,
+  validateString,
+  validateUrl,
+} from './validators';
+
+let opts: ValidationOptions;
+
+beforeEach(() => {
+  opts = { property: 'test', messages: {} };
+});
+
+describe('locationSuffix', () => {
+  it('empty opts return empty string', async () => {
+    expect(locationSuffix(opts)).toEqual('');
+  });
+  it('file opts return file', async () => {
+    expect(locationSuffix({ ...opts, file: 'file.ts' })).toEqual(' (at file.ts)');
+  });
+  it('location opts return location', async () => {
+    expect(locationSuffix({ ...opts, location: 'loc' })).toEqual(' (at loc)');
+  });
+  it('file/location opts return file/location', async () => {
+    expect(locationSuffix({ ...opts, file: 'file.ts', location: 'loc' })).toEqual(
+      ' (at file.ts#loc)',
+    );
+  });
+});
+
+describe('incrementOptions', () => {
+  it('property sets location', async () => {
+    expect(incrementOptions('new', opts)).toEqual({ ...opts, property: 'new', location: 'test' });
+  });
+  it('property updates location', async () => {
+    expect(incrementOptions('new', { ...opts, location: 'object' })).toEqual({
+      ...opts,
+      property: 'new',
+      location: 'object.test',
+    });
+  });
+  it('errors/warnings are not lost', async () => {
+    const newOpts = incrementOptions('new', opts);
+    if (newOpts.messages) {
+      newOpts.messages.errors = ['a'];
+      newOpts.messages.warnings = ['b', 'c'];
+    }
+    expect(opts.messages).toEqual({ errors: ['a'], warnings: ['b', 'c'] });
+  });
+});
+
+describe('validateBoolean', () => {
+  it('true returns self', async () => {
+    expect(validateBoolean(true, opts)).toEqual(true);
+  });
+  it('false returns self', async () => {
+    expect(validateBoolean(false, opts)).toEqual(false);
+  });
+  it('"true" returns true', async () => {
+    expect(validateBoolean('true', opts)).toEqual(true);
+  });
+  it('"False" returns false', async () => {
+    expect(validateBoolean('False', opts)).toEqual(false);
+  });
+  it('invalid type errors', async () => {
+    expect(validateBoolean(0, opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+  it('invalid string errors', async () => {
+    expect(validateBoolean('t', opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('validateString', () => {
+  it('valid value returns self', async () => {
+    expect(validateString('a', opts)).toEqual('a');
+  });
+  it('invalid type errors', async () => {
+    expect(validateString({}, opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+  it('exceeding maxLenth errors', async () => {
+    expect(validateString('abc', { maxLength: 1, ...opts })).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+  it('regex match returns self', async () => {
+    expect(validateString('abc', { regex: '^[a-c]{3}$', ...opts })).toEqual('abc');
+  });
+  it('incompatible regex errors', async () => {
+    expect(validateString('abc', { regex: '^[a-c]{2}$', ...opts })).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+  it('escape function runs', async () => {
+    expect(validateString('abc', { maxLength: 3, escapeFn: (s) => `${s}${s}`, ...opts })).toEqual(
+      'abcabc',
+    );
+  });
+});
+
+describe('validateUrl', () => {
+  it('valid value returns self', async () => {
+    expect(validateUrl('https://example.com', opts)).toEqual('https://example.com');
+  });
+  it('invalid string errors', async () => {
+    expect(validateUrl('not a url', opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+  it('valid value includes', async () => {
+    expect(validateUrl('https://example.com', { ...opts, includes: 'le.c' })).toEqual(
+      'https://example.com',
+    );
+  });
+  it('valid value without includes errors', async () => {
+    expect(validateUrl('https://example.com', { ...opts, includes: 'example.org' })).toEqual(
+      undefined,
+    );
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('validateEmail', () => {
+  it('valid email returns self', async () => {
+    expect(validateEmail('example@example.com', opts)).toEqual('example@example.com');
+  });
+  it('invalid email errors', async () => {
+    expect(validateEmail('https://example.com', opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('validateDate', () => {
+  it.each([
+    '2021-12-14T10:43:51.777Z',
+    '14 Dec 2021',
+    '14 December 2021',
+    '2021, December 14',
+    '2021 December 14',
+    '12/14/2021',
+    '12-14-2021',
+    '2022/12/14',
+    '2022-12-14',
+  ])('valid date: %p', async (date: any) => {
+    expect(validateDate(date, opts)).toEqual(date);
+  });
+  it('date object is valid', async () => {
+    const date = new Date();
+    expect(validateDate(date, opts)).toEqual(date.toISOString());
+  });
+  it('invalid date errors', async () => {
+    expect(validateDate('https://example.com', opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('validateObject', () => {
+  it('valid value returns self', async () => {
+    expect(validateObject({ a: 1 }, opts)).toEqual({ a: 1 });
+  });
+  it('invalid type errors', async () => {
+    expect(validateObject('a', opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('validateKeys', () => {
+  it('empty value', async () => {
+    expect(validateKeys({}, {}, opts)).toEqual({});
+  });
+  it('required keys', async () => {
+    expect(validateKeys({ a: 1, b: 2 }, { required: ['a', 'b'] }, opts)).toEqual({ a: 1, b: 2 });
+  });
+  it('optional keys', async () => {
+    expect(validateKeys({ a: 1, b: 2 }, { optional: ['a', 'b'] }, opts)).toEqual({ a: 1, b: 2 });
+  });
+  it('extra keys filtered', async () => {
+    expect(validateKeys({ a: 1, b: 2, c: 3 }, { required: ['a'], optional: ['b'] }, opts)).toEqual({
+      a: 1,
+      b: 2,
+    });
+    expect(opts.messages?.warnings.length).toEqual(1);
+  });
+  it('missing required keys errors', async () => {
+    expect(validateKeys({ a: 1 }, { required: ['a', 'b'] }, opts)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('validateList', () => {
+  it('empty list', async () => {
+    expect(validateList([], opts, (val) => val)).toEqual([]);
+  });
+  it('simple list and index', async () => {
+    expect(validateList(['a', 'b', 'c'], opts, (val, ind) => `${val} ${ind}`)).toEqual([
+      'a 0',
+      'b 1',
+      'c 2',
+    ]);
+  });
+  it('list filters undefined values', async () => {
+    expect(validateList(['a', 'b', 'c'], opts, (val) => (val === 'c' ? undefined : val))).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+  it('invalid object errors', async () => {
+    expect(validateList({}, opts, (val) => val)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+  it('invalid string errors', async () => {
+    expect(validateList('abc', opts, (val) => val)).toEqual(undefined);
+    expect(opts.messages?.errors.length).toEqual(1);
+  });
+});
+
+describe('fillMissingKeys', () => {
+  it('primary supersedes secondary', async () => {
+    expect(fillMissingKeys({ a: 1 }, { a: 2 }, ['a'])).toEqual({ a: 1 });
+  });
+  it('secondary supersedes nothing', async () => {
+    expect(fillMissingKeys({}, { a: 2 }, ['a'])).toEqual({ a: 2 });
+  });
+  it('other filler keys ignored', async () => {
+    expect(fillMissingKeys({ a: 1, b: 2 }, { a: 2, c: 3, d: 4 }, ['a', 'd'])).toEqual({
+      a: 1,
+      b: 2,
+      d: 4,
+    });
+  });
+});

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -40,7 +40,7 @@ export function validationError(message: string, opts: ValidationOptions) {
   if (!messages.errors) messages.errors = [];
   messages.errors.push({
     property: opts.property,
-    message: `"${opts.property}" ${message}${locationSuffix(opts)}`,
+    message: `'${opts.property}' ${message}${locationSuffix(opts)}`,
   });
   return undefined;
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,251 @@
+import { formatDate } from '../helpers';
+
+type message = {
+  property: string;
+  message: string;
+};
+
+export type ValidationOptions = {
+  property: string;
+  file?: string;
+  location?: string;
+  suppressWarnings?: boolean;
+  suppressErrors?: boolean;
+  messages: { errors?: message[]; warnings?: message[] };
+  // escapeFn is only used in string validation
+  escapeFn?: (s: string) => string;
+};
+
+type KeyOptions = ValidationOptions & { returnInvalidPartial?: boolean };
+
+export function defined(val: any) {
+  return val != null;
+}
+
+export function locationSuffix(opts: Partial<ValidationOptions>) {
+  if (opts.file && opts.location) return ` (at ${opts.file}#${opts.location})`;
+  if (opts.file || opts.location) return ` (at ${opts.file || opts.location})`;
+  return '';
+}
+
+export function incrementOptions(property: string, opts: ValidationOptions) {
+  let location = opts.property;
+  if (opts.location) location = `${opts.location}.${opts.property}`;
+  return { ...opts, property, location };
+}
+
+export function validationError(message: string, opts: ValidationOptions) {
+  if (opts.suppressErrors) return undefined;
+  const { messages } = opts;
+  if (!messages.errors) messages.errors = [];
+  messages.errors.push({
+    property: opts.property,
+    message: `"${opts.property}" ${message}${locationSuffix(opts)}`,
+  });
+  return undefined;
+}
+
+export function validationMessage(message: string, opts: ValidationOptions) {
+  if (opts.suppressWarnings) return undefined;
+  const { messages } = opts;
+  if (!messages.warnings) messages.warnings = [];
+  messages.warnings.push({
+    property: opts.property,
+    message: `"${opts.property}" ${message}${locationSuffix(opts)}`,
+  });
+  return undefined;
+}
+
+/**
+ * Validate value is boolean
+ *
+ * String 'true' and 'false' are coerced to booleans; error on any other value, including 1/0, 't'/'f', etc.
+ */
+export function validateBoolean(input: any, opts: ValidationOptions) {
+  if (typeof input === 'string') {
+    if (input.toLowerCase() === 'true') return true;
+    if (input.toLowerCase() === 'false') return false;
+  }
+  if (input === true || input === false) return input;
+  return validationError('must be boolean', opts);
+}
+
+/**
+ * Validates string value
+ *
+ * Ensures string length is less than `maxLength` and matches regular expression `regex`.
+ * If `escapeFn` is provided, this will be applied to the output after other validation.
+ */
+export function validateString(
+  input: any,
+  opts: { maxLength?: number; regex?: string | RegExp } & ValidationOptions,
+): string | undefined {
+  if (typeof input !== 'string') return validationError(`must be string`, opts);
+  let value = input as string;
+  const maxLength = opts.maxLength || 500;
+  if (value.length > maxLength) {
+    return validationError(`must be less than ${maxLength} chars`, opts);
+  }
+  if (opts.regex && !value.match(opts.regex)) {
+    return validationError(`must match regex ${opts.regex}`, opts);
+  }
+  if (opts.escapeFn) {
+    value = opts.escapeFn(value);
+  }
+  return value;
+}
+
+/**
+ * Validate value is valid URL string of max length 2048
+ *
+ * If 'include' is provided, value must include it in the origin.
+ */
+export function validateUrl(input: any, opts: { includes?: string } & ValidationOptions) {
+  const value = validateString(input, { ...opts, maxLength: 2048 });
+  if (value === undefined) return value;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return validationError('must be valid URL', opts);
+  }
+  if (opts.includes && !url.origin.includes(opts.includes)) {
+    return validationError(`must include "${opts.includes}"`, opts);
+  }
+  return value;
+}
+
+/**
+ * Validate value is valid email
+ */
+export function validateEmail(input: any, opts: ValidationOptions) {
+  const value = validateString(input, opts);
+  if (value === undefined) return value;
+  const valid = value
+    .toLowerCase()
+    .match(
+      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+    );
+  if (!valid) {
+    return validationError('must be valid email address', opts);
+  }
+  return value;
+}
+
+/**
+ * Validate date string or object
+ *
+ * Uses javascript Date() constructor; any input to the constructor that returns
+ * a valid date is valid input. This includes ISO 8601 formatted strings and
+ * IETF timestamps are valid.
+ */
+export function validateDate(input: any, opts: ValidationOptions) {
+  const date = new Date(input);
+  if (!date.getDate()) {
+    return validationError(
+      `invalid date "${input}" - must be ISO 8601 format or IETF timestamp`,
+      opts,
+    );
+  }
+  return typeof input === 'string' ? input : formatDate(date);
+}
+
+/**
+ * Validates value is an object
+ */
+export function validateObject(input: any, opts: ValidationOptions) {
+  if (typeof input !== 'object') return validationError(`must be object`, opts);
+  return input as Record<string, any>;
+}
+
+/**
+ * Validate an object has all required keys
+ *
+ * Returns new object with only required/optional keys
+ */
+export function validateKeys(
+  input: Record<string, any>,
+  keys: { required?: string[]; optional?: string[] },
+  opts: KeyOptions,
+) {
+  const value: Record<string, any> = {};
+  let required = keys.required || [];
+  const optional = keys.optional || [];
+  const ignored: string[] = [];
+  Object.keys(input).forEach((k) => {
+    if (required.includes(k) || optional.includes(k)) {
+      value[k] = input[k];
+      required = required.filter((val) => val !== k);
+    } else {
+      ignored.push(k);
+    }
+  });
+  if (required.length) {
+    validationError(
+      `missing required key${required.length > 1 ? 's' : ''}: ${required.join(', ')}`,
+      opts,
+    );
+    if (!opts.returnInvalidPartial) return undefined;
+  }
+  if (ignored.length) {
+    validationMessage(
+      `extra key${ignored.length > 1 ? 's' : ''} ignored: ${ignored.join(', ')}`,
+      opts,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validates value is an object and has all required keys
+ *
+ * Returns new object with only required/optional keys
+ */
+export function validateObjectKeys(
+  input: any,
+  keys: { required?: string[]; optional?: string[] },
+  opts: KeyOptions,
+) {
+  const value = validateObject(input, opts);
+  if (value === undefined) return undefined;
+  return validateKeys(value, keys, opts);
+}
+
+/**
+ * Validate value is a list
+ */
+export function validateList<T>(
+  input: any,
+  opts: ValidationOptions,
+  itemValidator: (item: any, index: number) => T | undefined,
+) {
+  if (!Array.isArray(input)) {
+    return validationError('must be an array', opts);
+  }
+  const value = input as any[];
+  return value
+    .map((item, index) => itemValidator(item, index))
+    .filter((item): item is T => item !== undefined);
+}
+
+/**
+ * Copy 'base' object and fill any 'keys' that are missing with their values from 'filler'
+ */
+export function fillMissingKeys<T extends Record<string, any>>(
+  base: T,
+  filler: T,
+  keys: (keyof T | string)[],
+): T {
+  const output: T = { ...base };
+  keys.forEach((key) => {
+    if (!defined(output[key]) && defined(filler[key])) {
+      const k = key as keyof T;
+      output[k] = filler[k];
+    }
+  });
+  return output;
+}
+
+export function filterKeys(value: Record<string, any>, keys: string[]): Record<string, any> {
+  return fillMissingKeys({}, value, keys);
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -125,17 +125,17 @@ export function validateSubdomain(input: string, opts: ValidationOptions) {
   try {
     url = new URL(value);
   } catch {
-    return validationError(`must be valid domain: ${value}`, opts);
+    return validationError(`must be valid domain: ${input}`, opts);
   }
   const { hash, host, pathname, protocol, search } = url;
   if (protocol !== 'http:' && protocol !== 'https:') {
-    return validationError(`must have http/https protocol or no protocol: ${value}`, opts);
+    return validationError(`must have http/https protocol or no protocol: ${input}`, opts);
   }
   if ((pathname && pathname !== '/') || hash || search) {
-    return validationError(`must not specify path, query, or fragment: ${value}`, opts);
+    return validationError(`must not specify path, query, or fragment: ${input}`, opts);
   }
   if (!host.match(/^.+\..+\..+$/)) {
-    return validationError(`must be a subdomain: ${value}`, opts);
+    return validationError(`must be a subdomain: ${input}`, opts);
   }
   return host;
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -107,12 +107,37 @@ export function validateUrl(input: any, opts: { includes?: string } & Validation
   try {
     url = new URL(value);
   } catch {
-    return validationError('must be valid URL', opts);
+    return validationError(`must be valid URL: ${value}`, opts);
   }
   if (opts.includes && !url.origin.includes(opts.includes)) {
-    return validationError(`must include "${opts.includes}"`, opts);
+    return validationError(`must include "${opts.includes}": ${value}`, opts);
   }
   return value;
+}
+
+export function validateSubdomain(input: string, opts: ValidationOptions) {
+  let value = validateString(input, { ...opts, maxLength: 2048 });
+  if (value === undefined) return value;
+  if (!value.startsWith('https://') && !value.startsWith('http://')) {
+    value = `http://${value}`;
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return validationError(`must be valid domain: ${value}`, opts);
+  }
+  const { hash, host, pathname, protocol, search } = url;
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    return validationError(`must have http/https protocol or no protocol: ${value}`, opts);
+  }
+  if ((pathname && pathname !== '/') || hash || search) {
+    return validationError(`must not specify path, query, or fragment: ${value}`, opts);
+  }
+  if (!host.match(/^.+\..+\..+$/)) {
+    return validationError(`must be a subdomain: ${value}`, opts);
+  }
+  return host;
 }
 
 /**


### PR DESCRIPTION
This adds SiteConfig DTO, similar to that found in curvenotejs: https://github.com/curvenote/curvenotejs/blob/main/src/config/types.ts#L42

A few differences:
- Project has `remote` - support for this needs to be added in curvenotejs to clone an entire site from a single config
- Project `path` is optional - with `remote`, the local paths we clone projects into doesn't matter.
- All fields are optional - the client can fill in defaults that are not defined in the API
- For `created_by` and `date_created` I think we just pull these from the project, i.e. site config is created at the same time as project. We could also just leave these off...?