### PR TITLE
📢 Site Publish types and scopes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export * from './comments';
 export * from './templates';
 export * from './sites';
 export * from './launchpad';
+export * from './publish';

--- a/src/launchpad.ts
+++ b/src/launchpad.ts
@@ -17,3 +17,16 @@ export interface LaunchpadDTO {
     status: string;
   };
 }
+
+export type PubsubMessageAttributes = {
+  action: string;
+  id: string;
+  user_auth: string;
+  [key: string]: string;
+};
+
+export type LaunchpadMessageAttributes = PubsubMessageAttributes & {
+  action: 'launchpad';
+  source_url: string;
+  domain: string;
+};

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,0 +1,22 @@
+import { LaunchpadStatus } from './launchpad';
+import { BaseLinks } from './types';
+
+export interface SitePublishLinks extends BaseLinks {
+  site: string;
+  project: string;
+}
+
+export type SitePublishId = {
+  site: string;
+  publish: string;
+};
+
+export interface SitePublish {
+  id: SitePublishId;
+  status: LaunchpadStatus;
+  cdn?: string;
+  created_by: string;
+  date_created: Date;
+  date_modified: Date;
+  links: SitePublishLinks;
+}

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,5 +1,6 @@
+import { getDate } from './helpers';
 import { LaunchpadStatus, PubsubMessageAttributes } from './launchpad';
-import { BaseLinks } from './types';
+import { BaseLinks, JsonObject } from './types';
 
 export interface SitePublishLinks extends BaseLinks {
   site: string;
@@ -25,3 +26,15 @@ export type SitePublishMessageAttributes = PubsubMessageAttributes & {
   action: 'publish';
   site: string;
 };
+
+export function sitePublishFromDTO(json: JsonObject): SitePublish {
+  return {
+    id: json.id,
+    created_by: json.created_by ?? '',
+    cdn: json.cdn ?? '',
+    status: json.status ?? '',
+    date_created: getDate(json.date_created),
+    date_modified: getDate(json.date_modified),
+    links: { ...json.links },
+  };
+}

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -1,4 +1,4 @@
-import { LaunchpadStatus } from './launchpad';
+import { LaunchpadStatus, PubsubMessageAttributes } from './launchpad';
 import { BaseLinks } from './types';
 
 export interface SitePublishLinks extends BaseLinks {
@@ -20,3 +20,8 @@ export interface SitePublish {
   date_modified: Date;
   links: SitePublishLinks;
 }
+
+export type SitePublishMessageAttributes = PubsubMessageAttributes & {
+  action: 'publish';
+  site: string;
+};

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -26,6 +26,13 @@ export enum SCOPES {
   commentUpdate = 'project.comment.update',
   commentResolve = 'project.comment.resolve',
   commentDelete = 'project.comment.delete',
+  siteConfigRead = 'site.config.read',
+  siteConfigUpdate = 'site.config.update',
+  sitePublishRead = 'site.publish.read',
+  sitePublishCreate = 'site.publish.create',
+  sitePublishUpdate = 'site.publish.update',
+  siteRouterCreate = 'site.router.create',
+  siteRouterDelete = 'site.router.delete',
 }
 
 export interface CRUD {
@@ -50,8 +57,7 @@ export const scopes = {
     read: SCOPES.teamRead,
     update: SCOPES.teamUpdate,
     access: {
-      ...readWrite(SCOPES.teamAccessRead, SCOPES.teamAccessWrite),
-      delete: SCOPES.teamAccessDelete,
+      ...readWrite(SCOPES.teamAccessRead, SCOPES.teamAccessWrite, SCOPES.teamAccessDelete),
       leave: SCOPES.teamAccessLeave,
       list: SCOPES.teamAccessRead,
     },
@@ -102,6 +108,22 @@ export const scopes = {
       list: SCOPES.commentRead,
     },
   },
+  site: {
+    config: {
+      read: SCOPES.siteConfigRead,
+      update: SCOPES.siteConfigUpdate,
+    },
+    publish: {
+      create: SCOPES.sitePublishCreate,
+      read: SCOPES.sitePublishRead,
+      update: SCOPES.sitePublishUpdate,
+      list: SCOPES.sitePublishRead,
+    },
+    router: {
+      create: SCOPES.siteRouterCreate,
+      delete: SCOPES.siteRouterDelete,
+    },
+  },
 };
 
 export const scopesInRole: Record<ROLES, SCOPES[]> = {
@@ -113,12 +135,14 @@ export const scopesInRole: Record<ROLES, SCOPES[]> = {
     SCOPES.teamAccessWrite,
     SCOPES.teamAccessDelete,
     SCOPES.projectCreate,
+    SCOPES.siteRouterCreate,
   ],
   [ROLES.teamMember]: [
     SCOPES.teamRead,
     SCOPES.teamAccessRead,
     SCOPES.teamAccessLeave,
     SCOPES.projectCreate,
+    SCOPES.siteRouterCreate,
   ],
   [ROLES.projectOwner]: [
     SCOPES.projectRead,
@@ -136,6 +160,13 @@ export const scopesInRole: Record<ROLES, SCOPES[]> = {
     SCOPES.commentUpdate,
     SCOPES.commentResolve,
     SCOPES.commentDelete,
+    SCOPES.siteConfigRead,
+    SCOPES.siteConfigUpdate,
+    SCOPES.sitePublishRead,
+    SCOPES.sitePublishCreate,
+    SCOPES.sitePublishUpdate,
+    SCOPES.siteRouterCreate,
+    SCOPES.siteRouterDelete,
   ],
   [ROLES.projectEditor]: [
     SCOPES.projectRead,
@@ -147,6 +178,13 @@ export const scopesInRole: Record<ROLES, SCOPES[]> = {
     SCOPES.commentRead,
     SCOPES.commentWrite,
     SCOPES.commentResolve,
+    SCOPES.siteConfigRead,
+    SCOPES.siteConfigUpdate,
+    SCOPES.sitePublishRead,
+    SCOPES.sitePublishCreate,
+    SCOPES.sitePublishUpdate,
+    SCOPES.siteRouterCreate,
+    SCOPES.siteRouterDelete,
   ],
   [ROLES.projectComment]: [
     SCOPES.projectRead,

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -179,7 +179,6 @@ export const scopesInRole: Record<ROLES, SCOPES[]> = {
     SCOPES.commentWrite,
     SCOPES.commentResolve,
     SCOPES.siteConfigRead,
-    SCOPES.siteConfigUpdate,
     SCOPES.sitePublishRead,
     SCOPES.sitePublishCreate,
     SCOPES.sitePublishUpdate,
@@ -191,10 +190,16 @@ export const scopesInRole: Record<ROLES, SCOPES[]> = {
     SCOPES.blockRead,
     SCOPES.commentRead,
     SCOPES.commentWrite,
+    SCOPES.siteConfigRead,
   ],
-  [ROLES.projectView]: [SCOPES.projectRead, SCOPES.blockRead, SCOPES.commentRead],
+  [ROLES.projectView]: [
+    SCOPES.projectRead,
+    SCOPES.blockRead,
+    SCOPES.commentRead,
+    SCOPES.siteConfigRead,
+  ],
   [ROLES.manifest]: [SCOPES.projectRead],
-  [ROLES.public]: [SCOPES.teamRead, SCOPES.projectRead, SCOPES.blockRead],
+  [ROLES.public]: [SCOPES.teamRead, SCOPES.projectRead, SCOPES.blockRead, SCOPES.siteConfigRead],
 };
 
 function getScopes(role: ROLES): SCOPES[] {

--- a/src/utils/validators.spec.ts
+++ b/src/utils/validators.spec.ts
@@ -7,6 +7,7 @@ import {
   validateBoolean,
   validateDate,
   validateEmail,
+  validateEnum,
   validateKeys,
   validateList,
   validateObject,
@@ -14,6 +15,7 @@ import {
   validateSubdomain,
   validateUrl,
 } from './validators';
+import { LaunchpadStatus } from '../launchpad';
 
 let opts: ValidationOptions;
 
@@ -177,6 +179,20 @@ describe('validateEmail', () => {
   });
   it('invalid email errors', async () => {
     expect(validateEmail('https://example.com', opts)).toEqual(undefined);
+    expect(opts.messages.errors?.length).toEqual(1);
+  });
+});
+
+describe('validateEnum', () => {
+  it('valid enum value returns self', async () => {
+    expect(validateEnum<LaunchpadStatus>('completed', { ...opts, enum: LaunchpadStatus })).toEqual(
+      'completed',
+    );
+  });
+  it('invalid enum value errors', async () => {
+    expect(validateEnum<LaunchpadStatus>('invalid', { ...opts, enum: LaunchpadStatus })).toEqual(
+      undefined,
+    );
     expect(opts.messages.errors?.length).toEqual(1);
   });
 });

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -152,9 +152,27 @@ export function validateEmail(input: any, opts: ValidationOptions) {
       /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
     );
   if (!valid) {
-    return validationError('must be valid email address', opts);
+    return validationError(`must be valid email address: ${value}`, opts);
   }
   return value;
+}
+
+/**
+ * Validate value against enum
+ *
+ * Must provide enum object as both option 'enum' and the type variable.
+ */
+export function validateEnum<T>(
+  input: any,
+  opts: ValidationOptions & { enum: Record<string | number | symbol, any> },
+): T | undefined {
+  if (!Object.values(opts.enum).includes(input)) {
+    return validationError(
+      `invalid value '${input}' - must be one of [${Object.values(opts.enum).join(', ')}]`,
+      opts,
+    );
+  }
+  return input;
 }
 
 /**


### PR DESCRIPTION
- Moves pubsub attribute types here for `launchpad` and `publish` actions
- Adds `SitePublish` types for site publish jobs
- Adds new `site` scopes for `config`, `publish`, and `router`
- New validator function for enums!